### PR TITLE
Update readme to restart container on failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Let's assume:
 
 1. Run forwarder as a Docker container:
 ```bash
-docker run -d --name forwarder -p 127.0.0.1:8443:8443 --cap-add NET_ADMIN mysteriumnetwork/openvpn-forwarder \
+docker run -d --restart=on-failure --name forwarder -p 127.0.0.1:8443:8443 --cap-add NET_ADMIN mysteriumnetwork/openvpn-forwarder \
     --proxy.upstream-url="http://superproxy.com:8080" \
     --filter.hostnames="ipinfo.io"
 ```
@@ -36,7 +36,7 @@ Let's assume:
 
 1. Run forwarder as a Docker container:
 ```bash
-docker run -d --name forwarder --net openvpn_network --cap-add NET_ADMIN mysteriumnetwork/openvpn-forwarder \
+docker run -d --restart=on-failure --name forwarder --net openvpn_network --cap-add NET_ADMIN mysteriumnetwork/openvpn-forwarder \
     --proxy.upstream-url="http://superproxy.com:8080" \
     --filter.hostnames="ipinfo.io,whatismyipaddress.com"
 ```
@@ -97,7 +97,7 @@ docker exec -it openvpn iptables -t nat -A POSTROUTING ! -d forwarder -j MASQUER
 
 And the `forwarder` container should be started with the following environment variables:
 ```
-docker run -d --name forwarder --net openvpn_network -e "OPENVPN_SUBNET=192.168.255.0/24" -e "OPENVPN_SERVER=openvpn" \
+docker run -d --restart=on-failure --name forwarder --net openvpn_network -e "OPENVPN_SUBNET=192.168.255.0/24" -e "OPENVPN_SERVER=openvpn" \
     --cap-add NET_ADMIN mysteriumnetwork/openvpn-forwarder \
     --proxy.upstream-url="http://superproxy.com:8080" \
     --filter.hostnames="ipinfo.io,whatismyipaddress.com"
@@ -143,7 +143,7 @@ If you need to forward non standard port too, the following steps required:
 
 1. Start OpenVPN forwarder with the `--proxy.port-map` flag:
 ```bash
-docker run -d --name forwarder -p 127.0.0.1:8443:8443 --cap-add NET_ADMIN mysteriumnetwork/openvpn-forwarder \
+docker run -d --restart=on-failure --name forwarder -p 127.0.0.1:8443:8443 --cap-add NET_ADMIN mysteriumnetwork/openvpn-forwarder \
     --proxy.upstream-url="http://superproxy.com:8080" \
     --proxy.port-map=18443:8443,1234:1234
 ```


### PR DESCRIPTION
This is a fully docker configuration to restart containers on reboot. 
By default docker container will not be started after docker daemon restart:
> Do not automatically restart the container when it exits. This is the default.

https://docs.docker.com/engine/reference/run/#restart-policies---restart

This PR updates readme to make sure we are starting the container with a required restart policy. 

>An ever increasing delay (double the previous delay, starting at 100 milliseconds) is added before each restart to prevent flooding the server. This means the daemon will wait for 100 ms, then 200 ms, 400, 800, 1600, and so on until either the `on-failure` limit is hit, or when you `docker stop` or `docker rm -f` the container.

