### PR TITLE
E2E test for HTTP traffic

### DIFF
--- a/ci/commands/command_test_e2e.go
+++ b/ci/commands/command_test_e2e.go
@@ -18,87 +18,30 @@
 package commands
 
 import (
-	"errors"
 	"fmt"
 
-	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
 )
 
-var (
-	dockerCompose    = sh.RunCmd("docker-compose", "-f", "docker-compose.yml")
-	dockerComposeOut = sh.OutCmd("docker-compose", "-f", "docker-compose.yml")
-	ipTablesAppend   = sh.RunCmd("docker-compose", "exec", "forwarder", "iptables", "-t", "nat", "-A")
-	ipTablesDelete   = sh.RunCmd("docker-compose", "exec", "forwarder", "iptables", "-t", "nat", "-D")
-)
+var dockerCompose = sh.RunCmd("docker-compose", "-f", "docker-compose.yml")
 
 // TestE2E runs end-to-end test
 func TestE2E() (err error) {
 	fmt.Println("Starting E2E containers")
-	if err = dockerCompose("up", "-d"); err != nil {
+	if err = runCompose("up", "-d"); err != nil {
 		return err
 	}
+
 	defer func() {
 		fmt.Println("Forwarder logs:")
 		_ = runCompose("logs", "forwarder")
 		fmt.Println()
 
-		err = dockerCompose("down")
+		err = runCompose("down")
 	}()
 
-	mg.Deps(TestE2EHTTP, TestE2EHTTPS)
-	return nil
-}
-
-// TestE2EHTTPS runs end-to-end test for HTTPS traffic forwarding
-func TestE2EHTTPS() error {
-	originalIP := checkIP("https://api.ipify.org/?format=text")
-	fmt.Println("Original IP:", originalIP)
-
-	redirectRule := []string{"OUTPUT", "-p", "tcp", "-m", "tcp", "--dport", "443", "-j", "REDIRECT", "--to-ports", "8443"}
-	if err := ipTablesAppend(redirectRule...); err != nil {
-		return err
-	}
-	defer ipTablesDelete(redirectRule...)
-
-	currentIP := checkIP("https://api.ipify.org/?format=text")
-	fmt.Println("Current IP:", currentIP)
-
-	if currentIP == originalIP {
-		return errors.New("request proxying failed")
-	}
-	fmt.Printf("Request successfuly proxied: %s -> %s", originalIP, currentIP)
-	return nil
-}
-
-// TestE2EHTTP runs end-to-end test for HTTP traffic forwarding
-func TestE2EHTTP() error {
-	originalIP := checkIP("http://api.ipify.org/?format=text")
-	fmt.Println("Original IP:", originalIP)
-
-	redirectRule := []string{"OUTPUT", "-p", "tcp", "-m", "tcp", "--dport", "80", "-j", "REDIRECT", "--to-ports", "8443"}
-	if err := ipTablesAppend(redirectRule...); err != nil {
-		return err
-	}
-	defer ipTablesDelete(redirectRule...)
-
-	currentIP := checkIP("http://api.ipify.org/?format=text")
-	fmt.Println("Current IP:", currentIP)
-
-	if currentIP == originalIP {
-		return errors.New("request proxying failed")
-	}
-	fmt.Printf("Request successfuly proxied: %s -> %s", originalIP, currentIP)
-	return nil
-}
-
-func checkIP(apiURL string) string {
-	ip, err := dockerComposeOut("exec", "forwarder", "wget", "-q", "-O", "-", apiURL)
-	if err != nil {
-		panic(err)
-	}
-
-	return ip
+	fmt.Println("Starting E2E tests")
+	return runCompose("run", "-T", "machine", "go", "test", "-v", "-tags=e2e", "./e2e/...")
 }
 
 func runCompose(args ...string) error {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,15 @@ services:
       --proxy.pass=
       --filter.zones=api.ipify.org
       --exclude.hostnames=ipify.org
+    ports:
+    - "8443:8443"
+
+  machine:
+    build:
+      context: .
+      dockerfile: e2e/Dockerfile
+    volumes:
+      - .:/go/src/github.com/mysteriumnetwork/openvpn-forwarder
     cap_add:
     - NET_ADMIN
     - NET_RAW
-    ports:
-    - "8443:8443"

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.18-alpine
+
+# Install packages
+RUN apk add --update --no-cache bash git gcc musl-dev make iptables bind-tools
+
+# Install application
+WORKDIR /go/src/github.com/mysteriumnetwork/openvpn-forwarder
+ADD . .

--- a/e2e/proxy_test.go
+++ b/e2e/proxy_test.go
@@ -1,0 +1,89 @@
+//go:build e2e
+// +build e2e
+
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/openvpn-forwarder" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package e2e
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/magefile/mage/sh"
+)
+
+var (
+	ipTablesAppend = sh.RunCmd("iptables", "-t", "nat", "-A")
+	ipTablesDelete = sh.RunCmd("iptables", "-t", "nat", "-D")
+)
+
+// TestHTTPS runs end-to-end test for HTTPS traffic forwarding
+func TestHTTPS(t *testing.T) {
+	// given
+	originalIP, err := checkIP("https://api.ipify.org/?format=text")
+	t.Log("Original IP:", originalIP)
+	assert.NoError(t, err)
+
+	forwarderIP, err := getForwarderIP()
+	assert.NoError(t, err)
+
+	// when
+	redirectRule := []string{"OUTPUT", "-p", "tcp", "-m", "tcp", "--dport", "443", "-j", "DNAT", "--to-destination", forwarderIP + ":8443"}
+	err = ipTablesAppend(redirectRule...)
+	defer ipTablesDelete(redirectRule...)
+	assert.NoError(t, err)
+
+	// then
+	currentIP, err := checkIP("https://api.ipify.org/?format=text")
+	t.Log("Current IP:", currentIP)
+	assert.NoError(t, err)
+
+	assert.NotEqualf(t, originalIP, currentIP, "Request proxying failed: %s -> %s", originalIP, currentIP)
+}
+
+// TestHTTP runs end-to-end test for HTTP traffic forwarding
+func TestHTTP(t *testing.T) {
+	// given
+	originalIP, err := checkIP("http://api.ipify.org/?format=text")
+	t.Log("Original IP:", originalIP)
+	assert.NoError(t, err)
+
+	forwarderIP, err := getForwarderIP()
+	assert.NoError(t, err)
+
+	// when
+	redirectRule := []string{"OUTPUT", "-p", "tcp", "-m", "tcp", "--dport", "80", "-j", "DNAT", "--to-destination", forwarderIP + ":8443"}
+	err = ipTablesAppend(redirectRule...)
+	defer ipTablesDelete(redirectRule...)
+	assert.NoError(t, err)
+
+	currentIP, err := checkIP("http://api.ipify.org/?format=text")
+	t.Log("Current IP:", currentIP)
+	assert.NoError(t, err)
+
+	assert.NotEqualf(t, originalIP, currentIP, "Request proxying failed: %s -> %s", originalIP, currentIP)
+}
+
+func getForwarderIP() (string, error) {
+	return sh.Output("dig", "forwarder", "+short")
+}
+
+func checkIP(apiURL string) (string, error) {
+	return sh.Output("wget", "-q", "-O", "-", apiURL)
+}


### PR DESCRIPTION
Before E2E test was run in forwarder machine itself, so port 80 requests was looping and `TestE2EHTTP` was not working.
This simulates actual environment with test runner and forwarder on different machines.