### PR TITLE
Gracefully handle HTTP requests with close header

### DIFF
--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.18-alpine
 
 # Install packages
-RUN apk add --update --no-cache bash git gcc musl-dev make iptables bind-tools
+RUN apk add --update --no-cache bash git gcc musl-dev make iptables bind-tools curl
 
 # Install application
 WORKDIR /go/src/github.com/mysteriumnetwork/openvpn-forwarder

--- a/proxy/server.go
+++ b/proxy/server.go
@@ -18,12 +18,12 @@
 package proxy
 
 import (
+	"bufio"
 	"crypto/tls"
 	"io"
 	"log"
 	"net"
 	"net/http"
-	"net/http/httputil"
 	"net/url"
 	"strings"
 
@@ -94,8 +94,7 @@ func (s *proxyServer) handler(l net.Listener, f func(c net.Conn)) {
 }
 
 func (s *proxyServer) serveHTTP(c net.Conn) {
-	sc := httputil.NewServerConn(c, nil)
-	req, err := sc.Read()
+	req, err := http.ReadRequest(bufio.NewReader(c))
 	if err != nil {
 		log.Printf("Failed to read HTTP request: %v", err)
 		return


### PR DESCRIPTION
This fixed transparent proxy to handle HTTP traffic requests like this one:
```
curl -k -i --raw -o 0.dat -X POST  -H "Host: i4.c.eset.com:80" -H "Connection: close" -H "Content-Type: application/octet-stream" "http://i4.c.eset.com:80/livegrid"
```