### PR TITLE
Implement access log

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       context: .
       dockerfile: Dockerfile
     command: >
+      --log.level=trace
       --proxy.bind=:8443
       --proxy.upstream-url=http://superproxy.com:8080
       --proxy.user=

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 )
 
 require (
+	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 h1:kHaBemcxl8o/pQ5VM1c8PVE1PubbNx3mjUr09OqWGCs=
+github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575/go.mod h1:9d6lWj8KzO/fd/NrVaLscBKmPigpZpn5YawRPw+e3Yo=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/magefile.go
+++ b/magefile.go
@@ -1,3 +1,4 @@
+//go:build mage
 // +build mage
 
 /*
@@ -38,6 +39,7 @@ func Build() error {
 // Run the application
 func Run() error {
 	return sh.RunV(buildPath,
+		"--log.level=trace",
 		"--proxy.bind=:8443",
 		"--proxy.upstream-url=http://superproxy.com:8080",
 		"--proxy.user=",

--- a/proxy/context.go
+++ b/proxy/context.go
@@ -1,0 +1,14 @@
+package proxy
+
+import (
+	"net"
+)
+
+// Context is the Proxy context, contains useful information about every request.
+type Context struct {
+	scheme string
+	conn   net.Conn
+
+	destinationHost    string
+	destinationAddress string
+}

--- a/proxy/server_test.go
+++ b/proxy/server_test.go
@@ -19,7 +19,6 @@ package proxy
 
 import (
 	"bufio"
-	"log"
 	"net"
 	"net/http"
 	"net/url"
@@ -27,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	log "github.com/cihub/seelog"
 	"github.com/soheilhy/cmux"
 	"github.com/stretchr/testify/assert"
 )
@@ -82,7 +82,7 @@ func Test_Server_AuthHeaderAdded(t *testing.T) {
 func listenAndServe(s *proxyServer) string {
 	ln, err := net.Listen("tcp", ":0")
 	if err != nil {
-		log.Fatalf("Error listening for https connections - %v", err)
+		log.Criticalf("Error listening for https connections - %v", err)
 	}
 
 	m := cmux.New(ln)

--- a/proxy/stickiness.go
+++ b/proxy/stickiness.go
@@ -20,8 +20,8 @@ package proxy
 import (
 	"crypto/sha256"
 	"encoding/base64"
-	"log"
 
+	log "github.com/cihub/seelog"
 	"github.com/tidwall/buntdb"
 )
 
@@ -44,7 +44,7 @@ func NewStickyMapper(path string) (*stickyMapper, error) {
 
 // Save creates or updated IP to UserID mapping.
 func (sm *stickyMapper) Save(ip, userID string) {
-	log.Printf("Adding stickiness: %s -> %s", ip, userID)
+	log.Infof("Adding stickiness: %s -> %s", ip, userID)
 
 	hashSum := sha256.Sum256([]byte(userID))
 	err := sm.cache.Update(func(tx *buntdb.Tx) error {
@@ -52,7 +52,7 @@ func (sm *stickyMapper) Save(ip, userID string) {
 		return err
 	})
 	if err != nil {
-		log.Println("Failed to save IP to UserID mapping: ", err)
+		_ = log.Warnf("Failed to save IP to UserID mapping: %s -> %s (%v)", ip, userID, err)
 	}
 }
 
@@ -66,8 +66,8 @@ func (sm *stickyMapper) Hash(ip string) (hash string) {
 		return hash
 	}
 
-	log.Println("Failed to load IP to UserID mapping: ", ip, err)
-	log.Println("Falling back to IP-stickiness")
+	_ = log.Warnf("Failed to load IP to UserID mapping for IP %s (%v)", ip, err)
+	log.Trace("Falling back to IP-stickiness")
 	hashSum := sha256.Sum256([]byte(ip))
 	return base64.URLEncoding.EncodeToString(hashSum[:])
 }


### PR DESCRIPTION
Before we're blind about what's happening  in transparent proxy.
This brings access log of of passing requests in format:
```
HTTPS request [client_addr=172.18.0.3:38828, dest_addr=172.18.0.2:8443, destination_host=api.ipify.org:8443, destination_addr=api.ipify.org:443]

HTTP request [client_addr=172.18.0.3:58212, dest_addr=172.18.0.2:8443, destination_host=api.ipify.org, destination_addr=api.ipify.org:80]
```