### PR TITLE
Handle HTTPS requests without SNI

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Let's assume:
 ```bash
 docker run -d --restart=always --name forwarder --network host --cap-add NET_ADMIN mysteriumnetwork/openvpn-forwarder \
     --proxy.bind=0.0.0.0:8443 \
+    --proxy.allow=0.0.0.0/0 \
     --proxy.upstream-url="https://superproxy.com:443" \
     --filter.hostnames="ipinfo.io"
 ```
@@ -151,6 +152,7 @@ If you need to forward non standard port too, the following steps required:
 ```bash
 docker run -d --restart=always --name forwarder --network host --cap-add NET_ADMIN mysteriumnetwork/openvpn-forwarder \
     --proxy.bind=0.0.0.0:8443 \
+    --proxy.allow=0.0.0.0/0 \
     --proxy.upstream-url="https://superproxy.com:443" \
     --proxy.port-map=18443:8443,1234:1234
 ```

--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ Let's assume:
 1. Run forwarder as a Docker container:
 ```bash
 docker run -d --restart=always --name forwarder --network host --cap-add NET_ADMIN mysteriumnetwork/openvpn-forwarder \
-    --proxy.bind=127.0.0.1:8443 \
+    --proxy.bind=0.0.0.0:8443 \
     --proxy.upstream-url="https://superproxy.com:443" \
     --filter.hostnames="ipinfo.io"
 ```
 
 2. Redirect HTTP ports to forwarder:
 ```bash
-iptables -t nat -A PREROUTING -p tcp -m multiport --dports 80,443 -j DNAT --to-destination 127.0.0.1:8443
+iptables -t nat -A PREROUTING -p tcp -m multiport --dports 80,443 -j REDIRECT --to-ports 8443
 ```
 
 3. Forwarder redirects HTTP traffic to upstream HTTPS proxy (this case just hostname 'ipinfo.io'):
@@ -150,7 +150,7 @@ If you need to forward non standard port too, the following steps required:
 1. Start OpenVPN forwarder with the `--proxy.port-map` flag:
 ```bash
 docker run -d --restart=always --name forwarder --network host --cap-add NET_ADMIN mysteriumnetwork/openvpn-forwarder \
-    --proxy.bind=127.0.0.1:8443 \
+    --proxy.bind=0.0.0.0:8443 \
     --proxy.upstream-url="https://superproxy.com:443" \
     --proxy.port-map=18443:8443,1234:1234
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     command: >
       --log.level=trace
       --proxy.bind=:8443
+      --proxy.allow=0.0.0.0/0
       --proxy.upstream-url=http://superproxy.com:8080
       --proxy.user=
       --proxy.pass=

--- a/proxy/server_test.go
+++ b/proxy/server_test.go
@@ -40,7 +40,7 @@ func Test_Server_ServeHTTP(t *testing.T) {
 
 	req, _ := http.NewRequest("GET", "http://domain.com", nil)
 
-	proxyServer := NewServer(upstreamDialer, &url.URL{}, &stickyMapperStub{}, &noopTracer{}, nil)
+	proxyServer := NewServer(nil, []net.IP{net.ParseIP("::1")}, upstreamDialer, &url.URL{}, &stickyMapperStub{}, &noopTracer{}, nil)
 	proxyAddr := listenAndServe(proxyServer)
 
 	proxyURL, _ := url.Parse("http://" + proxyAddr)
@@ -67,7 +67,7 @@ func Test_Server_AuthHeaderAdded(t *testing.T) {
 
 	req, _ := http.NewRequest("GET", "http://domain.com", nil)
 
-	proxyServer := NewServer(upstreamDialer, &url.URL{}, &stickyMapperStub{}, &noopTracer{}, nil)
+	proxyServer := NewServer(nil, []net.IP{net.ParseIP("::1")}, upstreamDialer, &url.URL{}, &stickyMapperStub{}, &noopTracer{}, nil)
 	proxyAddr := listenAndServe(proxyServer)
 
 	proxyURL, _ := url.Parse("http://" + proxyAddr)


### PR DESCRIPTION
Before this change, a transparent proxy was just skipping TLS connection just without SNI.
Now non-SNI requests will be redirected to the recovered destination address (dest IP + dest port) from TCP packets.