### PR TITLE
Support of multiple upstream proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ Let's assume:
 docker run -d --restart=always --name forwarder --network host --cap-add NET_ADMIN mysteriumnetwork/openvpn-forwarder \
     --proxy.bind=0.0.0.0:8443 \
     --proxy.allow=0.0.0.0/0 \
-    --proxy.upstream-url="https://superproxy.com:443" \
-    --filter.hostnames="ipinfo.io"
+    --proxy.upstream-url="https://superproxy1.com:8443" \
+    --filter.hostnames="ipinfo.io" \
+    --proxy.upstream-url="http://superproxy2.com:8080" \
+    --filter.zones="ipify.org"
 ```
 
 2. Redirect HTTP ports to forwarder:

--- a/magefile.go
+++ b/magefile.go
@@ -41,6 +41,7 @@ func Run() error {
 	return sh.RunV(buildPath,
 		"--log.level=trace",
 		"--proxy.bind=:8443",
+		"--proxy.allow=127.0.0.1",
 		"--proxy.upstream-url=http://superproxy.com:8080",
 		"--proxy.user=",
 		"--proxy.pass=",

--- a/main.go
+++ b/main.go
@@ -99,7 +99,7 @@ func main() {
 	apiServer := api.NewServer(*proxyAPIAddr, sm, domainTracer)
 	go apiServer.ListenAndServe()
 
-	dialerUpstream := proxy.NewDialerHTTPConnect(proxy.DialerDirect, dialerUpstreamURL.Host, *proxyUser, *proxyPass, *proxyCountry)
+	dialerUpstream := proxy.NewDialerHTTPConnect(proxy.DialerDirect, dialerUpstreamURL, *proxyUser, *proxyPass, *proxyCountry)
 
 	var dialer netproxy.Dialer
 	if len(*filterHostnames) > 0 || len(*filterZones) > 0 {
@@ -140,7 +140,7 @@ func main() {
 		_ = log.Criticalf("Failed to parse port map: %v", err)
 		os.Exit(1)
 	}
-	proxyServer := proxy.NewServer(allowedSubnets, allowedIPs, dialer, dialerUpstreamURL, sm, domainTracer, portMap)
+	proxyServer := proxy.NewServer(allowedSubnets, allowedIPs, dialer, sm, domainTracer, portMap)
 
 	var wg sync.WaitGroup
 	for p := range portMap {


### PR DESCRIPTION
Now it's possible to pass as many --proxy.upstream-url` & `--filter.hostnames` pairs as needed.
It will forward some domains to one upstream proxy, and some domains to another upstream proxy.