### PR TITLE
POC of HAProxy based integration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,3 +26,11 @@ services:
     cap_add:
     - NET_ADMIN
     - NET_RAW
+
+  haproxy-forwarder:
+    image: haproxy
+    volumes:
+      - ./e2e/haproxy-forwarder:/usr/local/etc/haproxy
+    ports:
+    - "18080:18080"
+    - "19999:19999"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,3 +34,11 @@ services:
     ports:
     - "18080:18080"
     - "19999:19999"
+
+  haproxy-gateway:
+    image: haproxy
+    volumes:
+      - ./e2e/haproxy-gateway:/usr/local/etc/haproxy
+    ports:
+    - "28080:28080"
+    - "29999:29999"

--- a/e2e/haproxy-forwarder/haproxy.cfg
+++ b/e2e/haproxy-forwarder/haproxy.cfg
@@ -1,0 +1,30 @@
+global
+    # Logging
+    log stdout local0 debug
+
+defaults
+    timeout connect 5000
+    timeout client 50000
+    timeout server 50000
+
+    # Access log
+    log global
+    mode http
+    option httplog
+    option dontlognull
+    option logasap
+
+listen stats
+    bind *:19999
+    stats enable
+    stats uri /stats
+
+listen forwarder
+    bind 0.0.0.0:18080
+
+    mode http
+    option httplog
+
+    http-request add-header "User-Id" "%{+X}ci"
+    http-request add-header "Proxy-Authorization" "Basic ********"
+    server s1 superproxy.com:8080 ssl verify none check-ssl

--- a/e2e/haproxy-gateway/haproxy.cfg
+++ b/e2e/haproxy-gateway/haproxy.cfg
@@ -1,0 +1,29 @@
+global
+    # Logging
+    log stdout local0 debug
+
+defaults
+    timeout connect 5000
+    timeout client 50000
+    timeout server 50000
+
+    # Access log
+    log global
+    mode http
+    option httplog
+    option logasap
+    option dontlognull
+
+listen stats
+    bind *:29999
+    stats enable
+    stats uri /stats
+
+listen vpn-gateway
+    bind 0.0.0.0:28080
+
+    mode tcp
+    option tcplog
+
+    unique-id-format "%{+X}ci:%[hostname,hex]"
+    server s1 forwarder:8443 send-proxy-v2 proxy-v2-options unique-id

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/mattn/go-isatty v0.0.9 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/pires/go-proxyproto v0.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/tidwall/btree v0.0.0-20170113224114-9876f1454cf0 // indirect
 	github.com/tidwall/gjson v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mysteriumnetwork/go-ci v0.0.0-20190726090015-267593de918b h1:+v8YIQaiP3NZxcTQJyiaNDgxcsrV8XVpqCnei8yWhWg=
 github.com/mysteriumnetwork/go-ci v0.0.0-20190726090015-267593de918b/go.mod h1:Avj7bcXP55yeIY4vZ4G+DPVQpCqdLVs3LgoM3YW4JAs=
+github.com/pires/go-proxyproto v0.7.0 h1:IukmRewDQFWC7kfnb66CSomk2q/seBuilHBYFwyq0Hs=
+github.com/pires/go-proxyproto v0.7.0/go.mod h1:Vz/1JPY/OACxWGQNIRY2BeyDmpoaWmEP40O9LbuiFR4=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/magefile.go
+++ b/magefile.go
@@ -41,7 +41,7 @@ func Run() error {
 	return sh.RunV(buildPath,
 		"--log.level=trace",
 		"--proxy.bind=:8443",
-		"--proxy.allow=127.0.0.1",
+		"--proxy.allow=0.0.0.0/0",
 		"--proxy.upstream-url=http://superproxy.com:8080",
 		"--proxy.user=",
 		"--proxy.pass=",


### PR DESCRIPTION
Initial experiment with Golang's library for [HAProxy v1/v2 protocol](https://www.haproxy.org/download/2.6/doc/proxy-protocol.txt) support.

Can't find a way to read **unique ID TLV type** or other TLV types: 

```
forwarder_1          | ==serveHAProxy
forwarder_1          | ==PROXY header: &proxyproto.Header{Version:0x2, Command:0x21, TransportProtocol:0x11, SourceAddr:(*net.TCPAddr)(0xc0002b4f90), DestinationAddr:(*net.TCPAddr)(0xc0002b4fc0), rawTLVs:[]uint8{0x5, 0x0, 0x21, 0x41, 0x43, 0x31, 0x33, 0x30, 0x30, 0x30, 0x31, 0x3a, 0x33, 0x38, 0x33, 0x31, 0x33, 0x31, 0x33, 0x32, 0x36, 0x36, 0x36, 0x31, 0x36, 0x31, 0x36, 0x31, 0x33, 0x31, 0x36, 0x31, 0x33, 0x34, 0x33, 0x36}}
forwarder_1          | ==PROXY IPs: 172.19.0.2:28080, 172.19.0.1:64426
forwarder_1          | ==PROXY error: <nil>
forwarder_1          | ==PROXY body 110:
forwarder_1          | CONNECT ipinfo.io:443 HTTP/1.1
forwarder_1          | Host: ipinfo.io:443
forwarder_1          | User-Agent: curl/7.88.1
forwarder_1          | Proxy-Connection: Keep-Alive
```

Updates: https://github.com/mysteriumnetwork/supernode/issues/533#issuecomment-1717519210